### PR TITLE
If a query is fast, I don't care if it uses indexes or not

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['mysql']['reload_action'] = "none"
+default['mysql']['tuning']['log_queries_not_using_index'] = false


### PR DESCRIPTION
Lets just make this default 'til we start needing to go OCD on indexing; right now we're generating about 1 GB of query log data daily with this setting on, and almost all of it completes in under a hundredth of a second or faster.
