### PR TITLE
Fix not being being to convert a master into a slave

### DIFF
--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -16,6 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+ip = Percona::ConfigHelper.bind_to(master_node.first,
+                                   replication['master_interface'])
+
+node.default['percona']['server']['role'] = 'slave'
+node.default['percona']['server']['server_id'] = 2
+node.default['percona']['server']['replication']['read_only'] = true
+node.default['percona']['server']['replication']['host'] = ip
+node.default['percona']['server']['replication']['username'] = 'replication'
+
 replication = node['osl-mysql']['replication']
 
 master_node = []
@@ -29,11 +39,4 @@ end
 
 fail 'You should have one master node' unless master_node.length == 1
 
-ip = Percona::ConfigHelper.bind_to(master_node.first,
-                                   replication['master_interface'])
-node.default['percona']['server']['role'] = 'slave'
-node.default['percona']['server']['server_id'] = 2
-node.default['percona']['server']['replication']['read_only'] = true
-node.default['percona']['server']['replication']['host'] = ip
-node.default['percona']['server']['replication']['username'] = 'replication'
 include_recipe 'osl-mysql::server'


### PR DESCRIPTION
If a server was once a master, it will have `node['percona']['server']['role'] = 'master'`.  If you try to make it a slave later, it will do a Chef search for masters before setting `node['percona']['server']['role'] = 'slave'`.  Therefore it will get itself in the Chef search for masters and die.  This PR just sets the attributes before the search to fix that.

@osuosl-cookbooks/chefs Ready for review.