### PR TITLE
Create client recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,3 +29,6 @@ suites:
   - name: xtrabackuprb
     run_list:
       - recipe[osl-mysql::xtrabackuprb]
+  - name: client
+    run_list:
+      - recipe[osl-mysql::client]

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: osl-mysql
+# Recipe:: client
+#
+# Copyright (C) 2013 Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mysql_client 'default' do
+  not_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }
+  action :create
+end
+
+package 'mariadb' do
+  only_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }
+  action :install
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'osl-mysql::client' do
+  [CENTOS_7_OPTS, CENTOS_6_OPTS].each do |pltfrm|
+    context "on #{pltfrm[:platform]} #{pltfrm[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(pltfrm).converge(described_recipe)
+      end
+      case pltfrm
+      when CENTOS_7_OPTS
+        it do
+          expect(chef_run).to install_package('mariadb')
+        end
+      when CENTOS_6_OPTS
+        it do
+          expect(chef_run).to create_mysql_client('default')
+        end
+      end
+    end
+  end
+end

--- a/test/integration/client/serverspec/client_spec.rb
+++ b/test/integration/client/serverspec/client_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+if os[:family] == 'redhat' && os[:release].to_i == 7
+  describe package 'mariadb' do
+    it { should be_installed }
+  end
+else
+  describe package 'mysql' do
+    it { should be_installed }
+  end
+end


### PR DESCRIPTION
I am creating this so that we have a standard way to install the mysql client package. Centos 7 doesn't support the standard mysql client, so it needs to install mariadb