### PR TITLE
Lock postgresql cookbook to < 6.1.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,6 +17,7 @@ depends          'osl-munin'
 depends          'percona'
 depends          'sysctl'
 depends          'yum'
+depends          'postgresql', '< 6.1.2'
 
 supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'


### PR DESCRIPTION
The postgresql cookbook was recently deprecated [1].

[1] https://github.com/sous-chefs/postgresql/pull/519