### PR TITLE
Trivial patch to resolve versioning issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Cookbook sets up MySQL configuration defaults, enables the Percona yum repo
 # Requirements
 Cookbooks:: yum, nagios, sysctl, mysql
 
-Tested on CentOS 6.x
+Tested on CentOS 6.x and 7.x
 
 # Usage
 include_recipe "osl-mysql::server" and run Chef.  It should take care of the rest.


### PR DESCRIPTION
It looks like versioning is somewhat broken on this cookbook. The last bump
should've been to 1.0.7, but got bumped to 1.0.6 instead. Hopefully this trivial
patch will fix this finally.