### PR TITLE
Include additional GPG key for RPMs for Percona

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe 'osl-mysql'
 
 mysql_client 'default' do
   not_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,3 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+node.default['percona']['yum']['gpgkey'] =
+  'https://raw.githubusercontent.com/percona/percona-repositories/master/rpm/PERCONA-PACKAGING-KEY ' \
+  'http://www.percona.com/downloads/RPM-GPG-KEY-percona'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -48,6 +48,7 @@ node.default['percona']['server']['innodb_buffer_pool_size'] =
 
 node.default['base']['sysctl']['vm.swappiness'] = '0'
 
+include_recipe 'osl-mysql'
 include_recipe 'base::sysctl'
 include_recipe 'percona::server'
 include_recipe 'percona::toolkit'

--- a/recipes/xtrabackuprb.rb
+++ b/recipes/xtrabackuprb.rb
@@ -1,5 +1,6 @@
 include_recipe 'git'
 include_recipe 'osl-postfix'
+include_recipe 'osl-mysql'
 include_recipe 'percona::package_repo'
 include_recipe 'yum-epel' if node['platform_version'].to_i == 6
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,6 +9,9 @@ describe 'osl-mysql::client' do
       it do
         expect { chef_run }.to_not raise_error
       end
+      it do
+        expect(chef_run).to include_recipe('osl-mysql')
+      end
       case pltfrm
       when CENTOS_7_OPTS
         it do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -13,6 +13,7 @@ describe 'osl-mysql::server' do
       end
 
       %w(
+        osl-mysql
         base::sysctl
         percona::server
         percona::toolkit
@@ -28,7 +29,8 @@ describe 'osl-mysql::server' do
         expect(chef_run).to create_yum_repository('percona-noarch')
           .with(
             description: 'Percona noarch Packages',
-            baseurl: "http://repo.percona.com/centos/#{pltfrm[:version].to_i}/os/noarch/"
+            baseurl: "http://repo.percona.com/centos/#{pltfrm[:version].to_i}/os/noarch/",
+            gpgkey: 'https://raw.githubusercontent.com/percona/percona-repositories/master/rpm/PERCONA-PACKAGING-KEY http://www.percona.com/downloads/RPM-GPG-KEY-percona'
           )
       end
 

--- a/spec/xtrabackuprb_spec.rb
+++ b/spec/xtrabackuprb_spec.rb
@@ -22,8 +22,15 @@ describe 'osl-mysql::xtrabackuprb' do
           expect(chef_run).to_not include_recipe('yum-epel')
         end
       end
-      it do
-        expect(chef_run).to include_recipe('percona::package_repo')
+      %w(
+        git
+        osl-postfix
+        osl-mysql
+        percona::package_repo
+      ).each do |r|
+        it do
+          expect(chef_run).to include_recipe(r)
+        end
       end
       it do
         expect(chef_run).to install_package('percona-xtrabackup')


### PR DESCRIPTION
It seems as though the latest builds of the percona RPMs including signing with
an additional key which is not listed in the yum repository. This is breaking
automatic yum upgrades. I've created an upstream issue with Percona
percona/percona-repositories#3 to see if they can get this published on their
website. Afterwards, I'll submit a PR to the sous-chefs/percona repository.