### PR TITLE
Ensure we install Percona-Server-devel-56 when using Percona

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,3 +19,4 @@
 node.default['percona']['yum']['gpgkey'] =
   'https://raw.githubusercontent.com/percona/percona-repositories/master/rpm/PERCONA-PACKAGING-KEY ' \
   'http://www.percona.com/downloads/RPM-GPG-KEY-percona'
+node.default['percona']['client']['packages'] << "Percona-Server-devel-#{node['percona']['version'].tr('.', '')}"

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -35,6 +35,10 @@ describe 'osl-mysql::server' do
       end
 
       it do
+        expect(chef_run).to install_package('Percona-Server-devel-56')
+      end
+
+      it do
         expect(chef_run).to create_directory('/var/lib/mysql-files')
           .with(
             owner: 'mysql',

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -4,6 +4,7 @@ set :backend, :exec
 
 %w(
   Percona-Server-server-56
+  Percona-Server-devel-56
   Percona-Server-shared-56
   percona-toolkit
   percona-xtrabackup


### PR DESCRIPTION
This is currently breaking any initial deploys using Percona-Server that
requires the mysql2 gem. Not sure why this isn't included in the upstream
cookbook but this works around that issue.