### PR TITLE
Add support for installing Percona client in osl-mysql::client

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,3 +35,9 @@ suites:
   - name: client
     run_list:
       - recipe[osl-mysql::client]
+  - name: client-percona
+    run_list:
+      - recipe[osl-mysql::client]
+    attributes:
+      osl-mysql:
+        enable_percona_client: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,3 +3,4 @@ default['osl-mysql']['replication']['role'] = 'mysql-vip'
 default['osl-mysql']['monitor_user'] = 'monitor'
 default['osl-mysql']['xtrabackuprb']['version'] = '0.0.6'
 default['osl-mysql']['backup_dir'] = '/data/backup'
+default['osl-mysql']['enable_percona_client'] = false

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -18,12 +18,11 @@
 #
 include_recipe 'osl-mysql'
 
-mysql_client 'default' do
-  not_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }
-  action :create
-end
-
-package 'mariadb' do
-  only_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }
-  action :install
+if node['osl-mysql']['enable_percona_client']
+  include_recipe 'percona::client'
+else
+  pkg_name = node['platform_version'].to_i >= 7 ? 'mariadb' : 'mysql'
+  mysql_client 'default' do
+    package_name [pkg_name, "#{pkg_name}-devel"]
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -12,14 +12,37 @@ describe 'osl-mysql::client' do
       it do
         expect(chef_run).to include_recipe('osl-mysql')
       end
+      it do
+        expect(chef_run).to_not include_recipe('percona::client')
+      end
       case pltfrm
       when CENTOS_7_OPTS
         it do
-          expect(chef_run).to install_package('mariadb')
+          expect(chef_run).to create_mysql_client('default').with(package_name: %w(mariadb mariadb-devel))
         end
       when CENTOS_6_OPTS
         it do
-          expect(chef_run).to create_mysql_client('default')
+          expect(chef_run).to create_mysql_client('default').with(package_name: %w(mysql mysql-devel))
+        end
+      end
+      context 'percona client' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.normal['osl-mysql']['enable_percona_client'] = true
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to include_recipe('percona::client')
+        end
+        case pltfrm
+        when CENTOS_7_OPTS
+          it do
+            expect(chef_run).to_not create_mysql_client('default').with(package_name: %w(mariadb mariadb-devel))
+          end
+        when CENTOS_6_OPTS
+          it do
+            expect(chef_run).to_not create_mysql_client('default').with(package_name: %w(mysql mysql-devel))
+          end
         end
       end
     end

--- a/test/integration/client-percona/inspec/client_percona_spec.rb
+++ b/test/integration/client-percona/inspec/client_percona_spec.rb
@@ -1,0 +1,5 @@
+%w(Percona-Server-client-56 Percona-Server-devel-56).each do |p|
+  describe package(p) do
+    it { should be_installed }
+  end
+end

--- a/test/integration/client/inspec/client_spec.rb
+++ b/test/integration/client/inspec/client_spec.rb
@@ -1,9 +1,7 @@
-if os[:family] == 'redhat' && os[:release].to_i == 7
-  describe package 'mariadb' do
-    it { should be_installed }
-  end
-else
-  describe package 'mysql' do
+pkg_name = os.release.to_i >= 7 ? 'mariadb' : 'mysql'
+
+[pkg_name, "#{pkg_name}-devel"].each do |p|
+  describe package(p) do
     it { should be_installed }
   end
 end


### PR DESCRIPTION
Currently osl-mysql::client assumes you're not using Percona. This becomes a
problem especially in a testing environment where we may install Percona server
but still need to have the client installed. To work around this, I've made the
following changes:

- Created a new attribute ``node['osl-mysql']['enable_percona_client']`` (false by
  default)
- When using Percona, use percona::client instead of the ``mysql_client`` resource
  for better portability.
- Ensure we also install the devel packages for all variants of mysql

This should not impact current installations AFAIK other than maybe installing
the devel package if it doesn't already have it.