### PR TITLE
Import mysql resources from deprecated database cookbook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - 'metadata.rb'
     - '**/vms/*'
+    - 'libraries/provider_database_mysql_user.rb'
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only

--- a/Berksfile
+++ b/Berksfile
@@ -10,6 +10,5 @@ cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
 cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 cookbook 'osl-postfix', git: 'git@github.com:osuosl-cookbooks/osl-postfix'
-cookbook 'osl-postgresql', git: 'git@github.com:osuosl-cookbooks/osl-postgresql'
 
 metadata

--- a/libraries/hashed_password.rb
+++ b/libraries/hashed_password.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Maksim Horbul (<max@gorbul.net>)
+# Cookbook:: database
+# Library:: hashed_password
+#
+# Copyright:: 2016, Eligible, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.join(File.dirname(__FILE__), 'resource_mysql_database_user')
+
+class HashedPassword
+  # Initializes an object of the MysqlPassword type
+  # @param [String] hashed_password mysql native hashed password
+  # @return [MysqlPassword]
+  def initialize(hashed_password)
+    @hashed_password = hashed_password
+  end
+
+  # String representation of the object
+  # @return [String] hashed password string
+  def to_s
+    @hashed_password
+  end
+
+  module Helpers
+    # helper method wrappers the string into a MysqlPassword object
+    # @param [String] hashed_password mysql native hashed password
+    # @return [MysqlPassword] object
+    def hashed_password(hashed_password)
+      HashedPassword.new hashed_password
+    end
+    # For backward compatibility, because method was renamed
+    alias_method :mysql_hashed_password, :hashed_password
+  end
+end
+
+::Chef::Resource::MysqlDatabaseUser.send(:include, HashedPassword::Helpers)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,186 @@
+#
+# Author:: Douglas Thrift (<douglas.thrift@rightscale.com>)
+# Cookbook:: database
+# Library:: matchers
+#
+# Copyright:: 2014-2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if defined?(ChefSpec)
+  # database
+  #
+  ChefSpec.define_matcher :database
+
+  def create_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database, :create, resource_name)
+  end
+
+  def drop_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database, :drop, resource_name)
+  end
+
+  def query_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database, :query, resource_name)
+  end
+
+  # database user
+  #
+  ChefSpec.define_matcher :database_user
+
+  def create_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database_user, :create, resource_name)
+  end
+
+  def drop_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database_user, :drop, resource_name)
+  end
+
+  def grant_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:database_user, :grant, resource_name)
+  end
+
+  # mysql database
+  #
+  ChefSpec.define_matcher :mysql_database
+
+  def create_mysql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database, :create, resource_name)
+  end
+
+  def drop_mysql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database, :drop, resource_name)
+  end
+
+  def query_mysql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database, :query, resource_name)
+  end
+
+  # mysql database user
+  #
+  ChefSpec.define_matcher :mysql_database_user
+
+  def create_mysql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database_user, :create, resource_name)
+  end
+
+  def drop_mysql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database_user, :drop, resource_name)
+  end
+
+  def grant_mysql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql_database_user, :grant, resource_name)
+  end
+
+  # postgresql database
+  #
+  ChefSpec.define_matcher :postgresql_database
+
+  def create_postgresql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database, :create, resource_name)
+  end
+
+  def drop_postgresql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database, :drop, resource_name)
+  end
+
+  def query_postgresql_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database, :query, resource_name)
+  end
+
+  # postgresql database schema
+  #
+  ChefSpec.define_matcher :postgresql_database_schema
+
+  def create_postgresql_database_schema(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_schema, :create, resource_name)
+  end
+
+  def drop_postgresql_database_schema(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_schema, :drop, resource_name)
+  end
+
+  # postgresql database user
+  #
+  ChefSpec.define_matcher :postgresql_database_user
+
+  def create_postgresql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_user, :create, resource_name)
+  end
+
+  def drop_postgresql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_user, :drop, resource_name)
+  end
+
+  def grant_postgresql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_user, :grant, resource_name)
+  end
+
+  def grant_schema_postgresql_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:postgresql_database_user, :grant_schema, resource_name)
+  end
+
+  # sql server database
+  #
+  ChefSpec.define_matcher :sql_server_database
+
+  def create_sql_server_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database, :create, resource_name)
+  end
+
+  def drop_sql_server_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database, :drop, resource_name)
+  end
+
+  def query_sql_server_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database, :query, resource_name)
+  end
+
+  # sql server database user
+  #
+  ChefSpec.define_matcher :sql_server_database_user
+
+  def create_sql_server_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database_user, :create, resource_name)
+  end
+
+  def drop_sql_server_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database_user, :drop, resource_name)
+  end
+
+  def grant_sql_server_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database_user, :grant, resource_name)
+  end
+
+  def alter_roles_sql_server_database_user(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sql_server_database_user, :alter_roles, resource_name)
+  end
+
+  # sqlite server database
+  #
+  ChefSpec.define_matcher :sqlite_database
+
+  def create_sqlite_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sqlite_database, :create, resource_name)
+  end
+
+  def query_sqlite_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sqlite_database, :query, resource_name)
+  end
+
+  def drop_sqlite_database(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sqlite_database, :drop, resource_name)
+  end
+
+end

--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -1,0 +1,166 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Sean OMeara (<sean@sean.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Provider
+    class Database
+      class Mysql < Chef::Provider::LWRPBase
+        use_inline_resources
+
+        def whyrun_supported?
+          true
+        end
+
+        action :create do
+          # test
+          schema_present = nil
+
+          begin
+            test_sql = 'SHOW SCHEMAS;'
+            Chef::Log.debug("#{new_resource.name}: Performing query [#{test_sql}]")
+            test_sql_results = test_client.query(test_sql)
+            test_sql_results.each do |r|
+              schema_present = true if r['Database'] == new_resource.database_name
+            end
+          ensure
+            close_test_client
+          end
+
+          # repair
+          unless schema_present
+            converge_by "Creating schema '#{new_resource.database_name}'" do
+              begin
+                repair_sql = "CREATE SCHEMA IF NOT EXISTS `#{new_resource.database_name}`"
+                repair_sql += " CHARACTER SET = #{new_resource.encoding}" if new_resource.encoding
+                repair_sql += " COLLATE = #{new_resource.collation}" if new_resource.collation
+                Chef::Log.debug("#{new_resource.name}: Performing query [#{repair_sql}]")
+                repair_client.query(repair_sql)
+              ensure
+                close_repair_client
+              end
+            end
+          end
+        end
+
+        action :drop do
+          # test
+          schema_present = nil
+
+          begin
+            test_sql = 'SHOW SCHEMAS;'
+            Chef::Log.debug("Performing query [#{test_sql}]")
+            test_sql_results = test_client.query(test_sql)
+            test_sql_results.each do |r|
+              schema_present = true if r['Database'] == new_resource.database_name
+            end
+          ensure
+            close_test_client
+          end
+
+          # repair
+          if schema_present
+            converge_by "Dropping schema '#{new_resource.database_name}'" do
+              begin
+                repair_sql = "DROP SCHEMA IF EXISTS `#{new_resource.database_name}`"
+                Chef::Log.debug("Performing query [#{repair_sql}]")
+                repair_client.query(repair_sql)
+              ensure
+                close_repair_client
+              end
+            end
+          end
+        end
+
+        action :query do
+          begin
+            query_sql = new_resource.sql_query
+            Chef::Log.debug("Performing query [#{query_sql}]")
+            query_client.query(query_sql)
+          ensure
+            close_query_client
+          end
+        end
+
+        private
+
+        def test_client
+          require 'mysql2'
+          @test_client ||=
+            Mysql2::Client.new(
+              host: new_resource.connection[:host],
+              socket: new_resource.connection[:socket],
+              username: new_resource.connection[:username],
+              password: new_resource.connection[:password],
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
+            )
+        end
+
+        def close_test_client
+          @test_client.close if @test_client
+        rescue Mysql2::Error
+          @test_client = nil
+        end
+
+        def repair_client
+          require 'mysql2'
+          @repair_client ||=
+            Mysql2::Client.new(
+              host: new_resource.connection[:host],
+              socket: new_resource.connection[:socket],
+              username: new_resource.connection[:username],
+              password: new_resource.connection[:password],
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
+            )
+        end
+
+        def close_repair_client
+          @repair_client.close if @repair_client
+        rescue Mysql2::Error
+          @repair_client = nil
+        end
+
+        def query_client
+          require 'mysql2'
+          @query_client ||=
+            Mysql2::Client.new(
+              host: new_resource.connection[:host],
+              socket: new_resource.connection[:socket],
+              username: new_resource.connection[:username],
+              password: new_resource.connection[:password],
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group],
+              flags: new_resource.connection[:flags],
+              database: new_resource.database_name
+            )
+        end
+
+        def close_query_client
+          @query_client.close if @query_client
+        rescue Mysql2::Error
+          @query_client = nil
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -21,7 +21,7 @@ class Chef
   class Provider
     class Database
       class Mysql < Chef::Provider::LWRPBase
-        use_inline_resources
+        use_inline_resources # ~FC113
 
         def whyrun_supported?
           true

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -1,0 +1,385 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Sean OMeara (<sean@sean.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.dirname(__FILE__), 'provider_database_mysql')
+
+class Chef
+  class Provider
+    class Database
+      class MysqlUser < Chef::Provider::Database::Mysql
+        use_inline_resources
+
+        def whyrun_supported?
+          true
+        end
+
+        action :create do
+          # test
+          user_present = nil
+          begin
+            test_sql = "SELECT User,Host from mysql.user WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}';"
+            test_sql_results = test_client.query(test_sql)
+            test_sql_results.each do |r|
+              user_present = true if r['User'] == new_resource.username
+            end
+
+            password_up_to_date = !user_present || test_user_password
+          ensure
+            close_test_client
+          end
+
+          # repair
+          unless user_present
+            converge_by "Creating user '#{new_resource.username}'@'#{new_resource.host}'" do
+              begin
+                repair_sql = "CREATE USER '#{new_resource.username}'@'#{new_resource.host}'"
+                if new_resource.password
+                  repair_sql += ' IDENTIFIED BY '
+                  repair_sql += if new_resource.password.is_a?(HashedPassword)
+                                  " PASSWORD '#{new_resource.password}'"
+                                else
+                                  " '#{new_resource.password}'"
+                                end
+                end
+                repair_client.query(repair_sql)
+              ensure
+                close_repair_client
+              end
+            end
+          end
+
+          update_user_password unless password_up_to_date
+        end
+
+        action :drop do
+          # test
+          user_present = nil
+          begin
+            test_sql = 'SELECT User,Host'
+            test_sql += ' from mysql.user'
+            test_sql += " WHERE User='#{new_resource.username}'"
+            test_sql += " AND Host='#{new_resource.host}'"
+            test_sql_results = test_client.query test_sql
+            test_sql_results.each do |r|
+              user_present = true if r['User'] == new_resource.username
+            end
+          ensure
+            close_test_client
+          end
+
+          # repair
+          if user_present
+            converge_by "Dropping user '#{new_resource.username}'@'#{new_resource.host}'" do
+              begin
+                repair_sql = 'DROP USER'
+                repair_sql += " '#{new_resource.username}'@'#{new_resource.host}'"
+                repair_client.query repair_sql
+              ensure
+                close_repair_client
+              end
+            end
+          end
+        end
+
+        action :grant do
+          # gratuitous function
+          def ishash?
+            return true if /(\A\*[0-9A-F]{40}\z)/i =~ new_resource.password
+          end
+
+          db_name = new_resource.database_name ? "`#{new_resource.database_name}`" : '*'
+          tbl_name = new_resource.table ? new_resource.table : '*'
+          test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
+
+          # Test
+          incorrect_privs = nil
+          begin
+            test_sql = "SELECT * from #{test_table}"
+            test_sql += " WHERE User='#{new_resource.username}'"
+            test_sql += " AND Host='#{new_resource.host}'"
+            test_sql += " AND Db='#{new_resource.database_name}'" if new_resource.database_name
+            test_sql_results = test_client.query test_sql
+
+            incorrect_privs = true if test_sql_results.size.zero?
+            # These should all be 'Y'
+            test_sql_results.each do |r|
+              desired_privs.each do |p|
+                key = p.to_s.capitalize.tr(' ', '_').gsub('Replication_', 'Repl_').gsub('Create_temporary_tables', 'Create_tmp_table').gsub('Show_databases', 'Show_db')
+                key = "#{key}_priv"
+                incorrect_privs = true if r[key] != 'Y'
+              end
+            end
+
+            password_up_to_date = incorrect_privs || test_user_password
+          ensure
+            close_test_client
+          end
+
+          # Repair
+          if incorrect_privs
+            converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
+              begin
+                repair_sql = "GRANT #{new_resource.privileges.join(',')}"
+                repair_sql += " ON #{db_name}.#{tbl_name}"
+                repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
+                repair_sql += if new_resource.password.is_a?(HashedPassword)
+                                " PASSWORD '#{new_resource.password}'"
+                              else
+                                " '#{new_resource.password}'"
+                              end
+                repair_sql += ' REQUIRE SSL' if new_resource.require_ssl
+                repair_sql += ' REQUIRE X509' if new_resource.require_x509
+                repair_sql += ' WITH GRANT OPTION' if new_resource.grant_option
+
+                redacted_sql = redact_password(repair_sql, new_resource.password)
+                Chef::Log.debug("#{@new_resource}: granting with sql [#{redacted_sql}]")
+                repair_client.query(repair_sql)
+                repair_client.query('FLUSH PRIVILEGES')
+              ensure
+                close_repair_client
+              end
+            end
+          else
+            # The grants are correct, but perhaps the password needs updating?
+            update_user_password unless password_up_to_date
+          end
+        end
+
+        action :revoke do
+          db_name = new_resource.database_name ? "`#{new_resource.database_name}`" : '*'
+          tbl_name = new_resource.table ? new_resource.table : '*'
+          test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
+
+          privs_to_revoke = []
+          begin
+            test_sql = "SELECT * from #{test_table}"
+            test_sql += " WHERE User='#{new_resource.username}'"
+            test_sql += " AND Host='#{new_resource.host}'"
+            test_sql += " AND Db='#{new_resource.database_name}'" if new_resource.database_name
+            test_sql_results = test_client.query test_sql
+
+            # These should all be 'N'
+            test_sql_results.each do |r|
+              desired_privs.each do |p|
+                key = p.to_s.capitalize.tr(' ', '_').gsub('Replication_', 'Repl_').gsub('Create_temporary_tables', 'Create_tmp_table').gsub('Show_databases', 'Show_db')
+                key = "#{key}_priv"
+                privs_to_revoke << revokify_key(p) if r[key] != 'N'
+              end
+            end
+          ensure
+            close_test_client
+          end
+
+          # Repair
+          unless privs_to_revoke.empty?
+            converge_by "Revoking privs for '#{new_resource.username}'@'#{new_resource.host}'" do
+              begin
+                revoke_statement = "REVOKE #{privs_to_revoke.join(',')}"
+                revoke_statement += " ON #{db_name}.#{tbl_name}"
+                revoke_statement += " FROM `#{@new_resource.username}`@`#{@new_resource.host}` "
+
+                Chef::Log.debug("#{@new_resource}: revoking access with statement [#{revoke_statement}]")
+                repair_client.query(revoke_statement)
+                repair_client.query('FLUSH PRIVILEGES')
+                @new_resource.updated_by_last_action(true)
+              ensure
+                close_repair_client
+              end
+            end
+          end
+        end
+
+        private
+
+        def desired_privs
+          possible_global_privs = [
+            :select,
+            :insert,
+            :update,
+            :delete,
+            :create,
+            :drop,
+            :references,
+            :index,
+            :alter,
+            :create_tmp_table,
+            :lock_tables,
+            :create_view,
+            :show_view,
+            :create_routine,
+            :alter_routine,
+            :execute,
+            :event,
+            :trigger,
+            :reload,
+            :shutdown,
+            :process,
+            :file,
+            :show_db,
+            :super,
+            :repl_slave,
+            :repl_client,
+            :create_user,
+          ]
+          possible_db_privs = [
+            :select,
+            :insert,
+            :update,
+            :delete,
+            :create,
+            :drop,
+            :references,
+            :index,
+            :alter,
+            :create_tmp_table,
+            :lock_tables,
+            :create_view,
+            :show_view,
+            :create_routine,
+            :alter_routine,
+            :execute,
+            :event,
+            :trigger,
+          ]
+
+          # convert :all to the individual db or global privs
+          desired_privs = if new_resource.privileges == [:all] && new_resource.database_name
+                            possible_db_privs
+                          elsif new_resource.privileges == [:all]
+                            possible_global_privs
+                          else
+                            new_resource.privileges
+                          end
+          desired_privs
+        end
+
+        def test_client
+          require 'mysql2'
+          @test_client ||=
+            Mysql2::Client.new(
+              host: new_resource.connection[:host],
+              socket: new_resource.connection[:socket],
+              username: new_resource.connection[:username],
+              password: new_resource.connection[:password],
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
+            )
+        end
+
+        def close_test_client
+          @test_client.close if @test_client
+        rescue Mysql2::Error
+          @test_client = nil
+        end
+
+        def repair_client
+          require 'mysql2'
+          @repair_client ||=
+            Mysql2::Client.new(
+              host: new_resource.connection[:host],
+              socket: new_resource.connection[:socket],
+              username: new_resource.connection[:username],
+              password: new_resource.connection[:password],
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
+            )
+        end
+
+        def close_repair_client
+          @repair_client.close if @repair_client
+        rescue Mysql2::Error
+          @repair_client = nil
+        end
+
+        def revokify_key(key)
+          return '' if key.nil?
+
+          # Some keys need to be translated as outlined by the table found here:
+          # https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html
+          result = key.to_s.downcase.tr('_', ' ').gsub('repl ', 'replication ').gsub('create tmp table', 'create temporary tables').gsub('show db', 'show databases')
+          result = result.gsub(/ priv$/, '')
+          result
+        end
+
+        def test_user_password
+          if database_has_password_column(test_client)
+            test_sql = 'SELECT User,Host,Password FROM mysql.user ' \
+                       "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' "
+            test_sql += if new_resource.password.is_a? HashedPassword
+                          "AND Password='#{new_resource.password}'"
+                        else
+                          "AND Password=PASSWORD('#{new_resource.password}')"
+                        end
+          else
+            test_sql = 'SELECT User,Host,authentication_string FROM mysql.user ' \
+                       "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' " \
+                       "AND plugin='mysql_native_password' "
+            test_sql += if new_resource.password.is_a? HashedPassword
+                          "AND authentication_string='#{new_resource.password}'"
+                        else
+                          "AND authentication_string=PASSWORD('#{new_resource.password}')"
+                        end
+          end
+          test_client.query(test_sql).size > 0
+        end
+
+        def update_user_password
+          converge_by "Updating password of user '#{new_resource.username}'@'#{new_resource.host}'" do
+            begin
+              if database_has_password_column(repair_client)
+                repair_sql = "SET PASSWORD FOR '#{new_resource.username}'@'#{new_resource.host}' = "
+                repair_sql += if new_resource.password.is_a? HashedPassword
+                                "'#{new_resource.password}'"
+                              else
+                                " PASSWORD('#{new_resource.password}')"
+                              end
+              else
+                # "ALTER USER is now the preferred statement for assigning passwords."
+                # http://dev.mysql.com/doc/refman/5.7/en/set-password.html
+                repair_sql = "ALTER USER '#{new_resource.username}'@'#{new_resource.host}' "
+                repair_sql += if new_resource.password.is_a? HashedPassword
+                                "IDENTIFIED WITH mysql_native_password AS '#{new_resource.password}'"
+                              else
+                                "IDENTIFIED BY '#{new_resource.password}'"
+                              end
+              end
+              repair_client.query(repair_sql)
+            ensure
+              close_repair_client
+            end
+          end
+        end
+
+        def database_has_password_column(client)
+          client.query('SHOW COLUMNS FROM mysql.user WHERE Field="Password"').size > 0
+        end
+
+        def redact_password(query, password)
+          if password.nil? || password == ''
+            query
+          else
+            query.gsub(password, 'REDACTED')
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -197,7 +197,7 @@ class Chef
                 Chef::Log.debug("#{@new_resource}: revoking access with statement [#{revoke_statement}]")
                 repair_client.query(revoke_statement)
                 repair_client.query('FLUSH PRIVILEGES')
-                @new_resource.updated_by_last_action(true)
+                @new_resource.updated_by_last_action(true) # ~FC085
               ensure
                 close_repair_client
               end

--- a/libraries/resource_database.rb
+++ b/libraries/resource_database.rb
@@ -1,0 +1,118 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+
+class Chef
+  class Resource
+    class Database < Chef::Resource
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :database
+        @database_name = name
+        @allowed_actions.push(:create, :drop, :query)
+        @action = :create
+      end
+
+      def database_name(arg = nil)
+        set_or_return(
+          :database_name,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def connection(arg = nil)
+        set_or_return(
+          :connection,
+          arg,
+          required: true
+        )
+      end
+
+      def sql(arg = nil, &block)
+        arg ||= block
+        set_or_return(
+          :sql,
+          arg,
+          kind_of: [String, Proc]
+        )
+      end
+
+      def sql_query
+        if sql.is_a?(Proc)
+          sql.call
+        else
+          sql
+        end
+      end
+
+      def template(arg = nil)
+        set_or_return(
+          :template,
+          arg,
+          kind_of: String,
+          default: 'DEFAULT'
+        )
+      end
+
+      def collation(arg = nil)
+        set_or_return(
+          :collation,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def encoding(arg = nil)
+        set_or_return(
+          :encoding,
+          arg,
+          kind_of: String,
+          default: 'DEFAULT'
+        )
+      end
+
+      def tablespace(arg = nil)
+        set_or_return(
+          :tablespace,
+          arg,
+          kind_of: String,
+          default: 'DEFAULT'
+        )
+      end
+
+      def connection_limit(arg = nil)
+        set_or_return(
+          :connection_limit,
+          arg,
+          kind_of: String,
+          default: '-1'
+        )
+      end
+
+      def owner(arg = nil)
+        set_or_return(
+          :owner,
+          arg,
+          kind_of: String
+        )
+      end
+    end
+  end
+end

--- a/libraries/resource_database_user.rb
+++ b/libraries/resource_database_user.rb
@@ -1,0 +1,114 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.dirname(__FILE__), 'resource_database')
+
+class Chef
+  class Resource
+    class DatabaseUser < Chef::Resource::Database
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :database_user
+        @username = name
+
+        @database_name = nil
+        @table = nil
+        @host = 'localhost'
+        @privileges = [:all]
+        @grant_option = false
+        @require_ssl = false
+        @require_x509 = false
+
+        @allowed_actions.push(:create, :drop, :grant, :revoke)
+        @action = :create
+      end
+
+      def database_name(arg = nil)
+        set_or_return(
+          :database_name,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def username(arg = nil)
+        set_or_return(
+          :username,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def require_ssl(arg = nil)
+        set_or_return(
+          :require_ssl,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def require_x509(arg = nil)
+        set_or_return(
+          :require_x509,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def password(arg = nil)
+        set_or_return(
+          :password,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def table(arg = nil)
+        set_or_return(
+          :table,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def host(arg = nil)
+        set_or_return(
+          :host,
+          arg,
+          kind_of: String
+        )
+      end
+
+      def privileges(arg = nil)
+        set_or_return(
+          :privileges,
+          arg,
+          kind_of: Array
+        )
+      end
+
+      def grant_option(arg = nil)
+        set_or_return(
+          :grant_option,
+          arg,
+          kind_of: [TrueClass, FalseClass], default: false
+        )
+      end
+    end
+  end
+end

--- a/libraries/resource_mysql_database.rb
+++ b/libraries/resource_mysql_database.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Sean OMeara (<sean@sean.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.dirname(__FILE__), 'provider_database_mysql')
+
+class Chef
+  class Resource
+    class MysqlDatabase < Chef::Resource::Database
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :mysql_database
+        @provider = Chef::Provider::Database::Mysql
+      end
+    end
+  end
+end

--- a/libraries/resource_mysql_database_user.rb
+++ b/libraries/resource_mysql_database_user.rb
@@ -1,0 +1,40 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: 2011-2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.dirname(__FILE__), 'resource_database_user')
+require File.join(File.dirname(__FILE__), 'provider_database_mysql_user')
+
+class Chef
+  class Resource
+    class MysqlDatabaseUser < Chef::Resource::DatabaseUser
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :mysql_database_user
+        @provider = Chef::Provider::Database::MysqlUser
+      end
+
+      def password(arg = nil)
+        set_or_return(
+          :password,
+          arg,
+          kind_of: [String, HashedPassword]
+        )
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.1'
 
 depends          'base'
-depends          'database'
 depends          'firewall'
 depends          'git'
 depends          'mysql', '~> 8.5.1'
@@ -22,7 +21,6 @@ depends          'percona', '~> 0.16.1'
 depends          'sysctl'
 depends          'yum'
 depends          'yum-epel'
-depends          'osl-postgresql'
 
 supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'


### PR DESCRIPTION
The database cookbook [1] has been deprecated upstream and is currently causing
conflicts with the postgresql cookbook due to duplicated resource names. However
there is no replacement (currently) for the mysql resources that we use in this
cookbook (and other cookbooks).

Let's go ahead and import these resources into our wrapper cookbook and remove
the database cookbook dependency. In addition, remove the osl-postgresql
dependency which isn't needed anymore.

[1] https://github.com/chef-boneyard/database