### PR TITLE
Change innodb file format and set log_bin_trust_function_creators

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -20,6 +20,12 @@ node.default['percona']['server']['debian_username'] = 'root'
 node.default['percona']['skip_passwords'] = false
 node.default['percona']['server']['bind_address'] = '0.0.0.0'
 
+# Loosen restrictions on type of functions users can create
+node.default['percona']['conf']['mysqld']['log_bin_trust_function_creators'] = '1'
+
+# utf8mb4 support
+node.default['percona']['conf']['mysqld']['innodb_large_prefix'] = 'true'
+
 # Tunables
 node.default['percona']['server']['binlog_format'] = 'mixed'
 node.default['percona']['server']['myisam_recover'] = 'FORCE,BACKUP'
@@ -35,6 +41,7 @@ node.default['percona']['server']['query_cache_size'] = 0
 node.default['percona']['server']['thread_cache_size'] = 50
 node.default['percona']['server']['key_buffer'] = '32M'
 node.default['percona']['server']['table_cache'] = 4_096
+node.default['percona']['server']['innodb_file_format'] = 'barracuda'
 node.default['percona']['server']['innodb_file_per_table'] = true
 node.default['percona']['server']['innodb_flush_method'] = 'O_DIRECT'
 node.default['percona']['server']['innodb_log_files_in_group'] = 2

--- a/test/integration/server/inspec/server_spec.rb
+++ b/test/integration/server/inspec/server_spec.rb
@@ -44,6 +44,15 @@ describe ini('/root/.my.cnf') do
   its('mysqldump.password') { should eq '\'jzYY0cQUnPAMcqvIxYaC\'' }
 end
 
+describe mysql_conf('/etc/my.cnf') do
+  its('mysqld.log_bin_trust_function_creators') { should eq '1' }
+  its('mysqld.innodb_large_prefix') { should eq 'true' }
+  # percona cookbook adds a second mysqld section for the above settings
+  # mysql_conf/ini inspec resource seems to only give you the second section
+  its('content') { should match(/^innodb_file_format = barracuda$/) }
+  its('content') { should match(/^innodb_file_per_table$/) }
+end
+
 describe kernel_parameter('vm.swappiness') do
   its('value') { should eq 0 }
 end


### PR DESCRIPTION
* Changes default innodb file format to support the utf8mb4 character set.
* Sets log_bin_trust_function_creators to allow less-safe functions to be created.