### PR TITLE
Include hashed_password from resource_mysql_database_user

### DIFF
--- a/libraries/hashed_password.rb
+++ b/libraries/hashed_password.rb
@@ -17,8 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.join(File.dirname(__FILE__), 'resource_mysql_database_user')
-
 class HashedPassword
   # Initializes an object of the MysqlPassword type
   # @param [String] hashed_password mysql native hashed password
@@ -44,5 +42,3 @@ class HashedPassword
     alias_method :mysql_hashed_password, :hashed_password
   end
 end
-
-::Chef::Resource::MysqlDatabaseUser.include HashedPassword::Helpers

--- a/libraries/resource_mysql_database_user.rb
+++ b/libraries/resource_mysql_database_user.rb
@@ -17,6 +17,7 @@
 #
 
 require File.join(File.dirname(__FILE__), 'resource_database_user')
+require File.join(File.dirname(__FILE__), 'hashed_password')
 require File.join(File.dirname(__FILE__), 'provider_database_mysql_user')
 
 class Chef


### PR DESCRIPTION
I believe this is due to a chicken and the egg problem where property now
expects this to be loaded while it while the previous method was working as is.

This works around the following error on production nodes:

```
NameError
---------
uninitialized constant Chef::Resource::MysqlDatabaseUser::HashedPassword

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/osl-mysql/libraries/resource_mysql_database_user.rb:32:in `<class:MysqlDatabaseUser>'
  /var/chef/cache/cookbooks/osl-mysql/libraries/resource_mysql_database_user.rb:24:in `<class:Resource>'
  /var/chef/cache/cookbooks/osl-mysql/libraries/resource_mysql_database_user.rb:23:in `<class:Chef>'
  /var/chef/cache/cookbooks/osl-mysql/libraries/resource_mysql_database_user.rb:22:in `<top (required)>'
  /var/chef/cache/cookbooks/osl-mysql/libraries/hashed_password.rb:20:in `<top (required)>'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/osl-mysql/libraries/resource_mysql_database_user.rb:

 25:        resource_name :mysql_database_user
 26:
 27:        def initialize(name, run_context = nil)
 28:          super
 29:          @provider = Chef::Provider::Database::MysqlUser
 30:        end
 31:
 32>>       property :password, [String, HashedPassword]
 33:      end
 34:    end
 35:  end
 36:
```