### PR TITLE
[Low Priority] Remove mysql2_chef_gem from test metadata

### DIFF
--- a/test/cookbooks/multi_node_test/metadata.rb
+++ b/test/cookbooks/multi_node_test/metadata.rb
@@ -7,5 +7,4 @@ version '0.1.0'
 chef_version '>= 13.0'
 
 depends 'base', '>= 3.0.0'
-depends 'mysql2_chef_gem'
 depends 'osl-mysql'


### PR DESCRIPTION
Just cleaning up the test metadata so eventually we can remove `chef-repo`'s `mysql2_chef_gem` dependency. I forgot to remove it in the initial PR