### PR TITLE
Update upstream percona to 2.1.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ depends          'mysql', '~> 8.5.1'
 depends          'osl-nrpe'
 depends          'osl-munin'
 depends          'osl-postfix'
-depends          'percona', '~> 2.0.0'
+depends          'percona', '~> 2.1.0'
 
 supports         'centos', '~> 7.0'
 supports         'centos', '~> 8.0'


### PR DESCRIPTION
To fix `repl_client` syntax issue for osl-prometheus