### PR TITLE
Use search() stubbing in ChefSpec

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,63 +41,63 @@ suites:
     attributes:
       osl-mysql:
         enable_percona_client: true
-#  - name: multi-node-7
-#    driver:
-#      name: terraform
-#      command_timeout: 1800
-#      variables:
-#          centos_image: 'CentOS 7.9'
-#    provisioner: terraform
-#    verifier:
-#      name: terraform
-#      systems:
-#        - name: master
-#          backend: ssh
-#          hosts_output: master
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - master
-#          hostnames: master
-#        - name: slave
-#          backend: ssh
-#          hosts_output: slave
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - slave
-#          hostnames: slave
-#    excludes:
-#      - centos-8
-#  - name: multi-node-8
-#    driver:
-#      name: terraform
-#      command_timeout: 1800
-#      variables:
-#          centos_image: 'CentOS 8.3'
-#    provisioner: terraform
-#    verifier:
-#      name: terraform
-#      systems:
-#        - name: master
-#          backend: ssh
-#          hosts_output: master
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - master
-#          hostnames: master
-#        - name: slave
-#          backend: ssh
-#          hosts_output: slave
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - slave
-#          hostnames: slave
-#    excludes:
-#      - centos-7
+  - name: multi-node-7
+    driver:
+      name: terraform
+      command_timeout: 1800
+      variables:
+          centos_image: 'CentOS 7.9'
+    provisioner: terraform
+    verifier:
+      name: terraform
+      systems:
+        - name: master
+          backend: ssh
+          hosts_output: master
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - master
+          hostnames: master
+        - name: slave
+          backend: ssh
+          hosts_output: slave
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - slave
+          hostnames: slave
+    excludes:
+      - centos-8
+  - name: multi-node-8
+    driver:
+      name: terraform
+      command_timeout: 1800
+      variables:
+          centos_image: 'CentOS 8.3'
+    provisioner: terraform
+    verifier:
+      name: terraform
+      systems:
+        - name: master
+          backend: ssh
+          hosts_output: master
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - master
+          hostnames: master
+        - name: slave
+          backend: ssh
+          hosts_output: slave
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - slave
+          hostnames: slave
+    excludes:
+      - centos-7

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -18,19 +18,14 @@
 #
 replication = node['osl-mysql']['replication']
 
-master_node = []
-if Chef::Config[:solo]
-  Chef::Log.warn('This recipe uses search which Chef Solo does not support')
-else
-  master_node = search(:node, "roles:#{replication['role']}").select do |n|
-    n if n['percona']['server']['role'].include?('master')
-  end
+master_node = search(:node, "roles:#{replication['role']}").select do |n|
+  n.dig('percona', 'server', 'role').include?('master')
 end
 
 raise 'You should have one master node' unless master_node.length == 1
 
-ip = Percona::ConfigHelper.bind_to(master_node.first,
-                                   replication['master_interface'])
+ip = Percona::ConfigHelper.bind_to(master_node.first, replication['master_interface'])
+
 node.default['percona']['server']['role'] = 'slave'
 node.default['percona']['server']['server_id'] = 2
 node.default['percona']['server']['replication']['read_only'] = true

--- a/spec/slave_spec.rb
+++ b/spec/slave_spec.rb
@@ -3,48 +3,52 @@ require 'spec_helper'
 describe 'osl-mysql::slave' do
   include_context 'common_stubs'
 
-  ALLPLATFORMS.each do |pltfrm|
-    context 'SoloRunner' do
-      cached(:chef_run) do
-        ChefSpec::SoloRunner.new(pltfrm).converge(described_recipe)
-      end
-      it do
-        expect { chef_run }.to raise_error.with_message('You should have one master node')
-      end
-    end
+  ALLPLATFORMS.each do |p|
+    context "on #{p[:platform]} #{p[:version]}" do
+      context 'with master node' do
+        platform p[:platform], p[:version]
 
-    context 'ServerRunner with master node' do
-      cached(:chef_run) do
-        master = stub_node('master', pltfrm) do |node|
-          node.normal['recipes'] = ['osl-mysql::master']
-          node.normal['roles'] = ['mysql-vip']
-          node.normal['percona']['server']['role'] = 'master'
+        before do
+          stub_search(:node, 'roles:mysql-vip').and_return(
+            [
+              {
+                name: 'master.example.org',
+                network: {
+                  interfaces: {
+                    eth1: {
+                      addresses: {
+                        "192.0.2.100": {
+                          family: 'inet',
+                        },
+                      },
+                    },
+                  },
+                },
+                percona: {
+                  server: {
+                    role: 'master',
+                  },
+                },
+              },
+            ]
+          )
         end
-        ChefSpec::ServerRunner.new(pltfrm) do |_node, server|
-          server.create_node(master)
-        end.converge(described_recipe)
-      end
-      it do
-        expect(chef_run).to include_recipe('osl-mysql::server')
-      end
-      it do
-        expect { chef_run }.not_to raise_error
-      end
-    end
 
-    context 'ServerRunner without master node' do
-      cached(:chef_run) do
-        slave = stub_node('slave', pltfrm) do |node|
-          node.normal['recipes'] = ['osl-mysql::slave']
-          node.normal['roles'] = ['mysql-vip']
-          node.normal['percona']['server']['role'] = 'slave'
+        it do
+          expect(chef_run).to include_recipe('osl-mysql::server')
         end
-        ChefSpec::ServerRunner.new(pltfrm) do |_node, server|
-          server.create_node(slave)
-        end.converge(described_recipe)
       end
-      it do
-        expect { chef_run }.to raise_error.with_message('You should have one master node')
+
+      context 'without master node' do
+        platform p[:platform], p[:version]
+
+        before do
+          stub_search(:node, 'roles:mysql-vip').and_return([])
+        end
+
+        it do
+          expect { chef_run }.to raise_error.with_message('You should have one master node')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,15 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-# rubocop:disable Style/MutableConstant
 CENTOS_8_OPTS = {
   platform: 'centos',
   version: '8',
-}
+}.freeze
 
 CENTOS_7_OPTS = {
   platform: 'centos',
   version: '7',
-}
-
-# rubocop:enable Style/MutableConstant
+}.freeze
 
 ALLPLATFORMS = [
   CENTOS_7_OPTS,

--- a/test/integration/multi-node-7/controls/all_spec.rb
+++ b/test/integration/multi-node-7/controls/all_spec.rb
@@ -130,7 +130,7 @@ control 'all' do
     end
   end
 
-  sql = mysql_session('root')
+  sql = mysql_session('root', 'jzYY0cQUnPAMcqvIxYaC')
   describe sql.query('SHOW databases') do
     its('stdout') { should match 'testdb' }
   end

--- a/test/integration/multi-node-7/controls/slave_spec.rb
+++ b/test/integration/multi-node-7/controls/slave_spec.rb
@@ -1,5 +1,5 @@
 control 'slave' do
-  describe mysql_session('root').query('SHOW SLAVE STATUS\G') do
+  describe mysql_session('root', 'jzYY0cQUnPAMcqvIxYaC').query('SHOW SLAVE STATUS\G') do
     its('stdout') { should match 'Slave_IO_State: Waiting for master to send event' }
     its('stdout') { should match 'Master_Host: 192.168.60.11' }
     its('stdout') { should match 'Master_User: replication' }


### PR DESCRIPTION
`search()` calls can be stubbed like databags in ChefSpec, and the current way using `stub_node()` does not work with the new ChefSpec format. Now that all Kitchen testing is done with Chef Zero, the only Chef Solo testing done is in ChefSpec and the skip can be removed.
