### PR TITLE
[osl_mysql_test] Disabled setting up mariadb's own repository

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description      'Installs/Configures osl-mysql'
 version          '6.7.0'
 
 depends          'git'
-depends          'mariadb', '~> 5.2.4'
+depends          'mariadb', '~> 5.2.19'
 depends          'mysql', '~> 11.0.5'
 depends          'osl-firewall'
 depends          'osl-nrpe'

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -17,6 +17,7 @@ action :create do
   # Install the package, and set up the service
   mariadb_server_install 'osl-mysql-test' do
     password new_resource.server_password
+    setup_repo false
     action [:install, :create]
   end
   # Create new database

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -1,6 +1,6 @@
 # Ensure that the port is bound, and the service is running.
 
-describe service('mysql.service') do
+describe service('mariadb.service') do
   it { should be_enabled }
   it { should be_running }
 end


### PR DESCRIPTION
There were issues with setting up the test repository depending on the distro image we were using, as the resource was attempting to install the same version, ignoring whatever version was available.