### PR TITLE
Added in `version` attribute to `osl_mysql_test`

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,4 @@ default['osl-mysql']['monitor_user'] = 'monitor'
 default['osl-mysql']['xtrabackuprb']['version'] = '0.0.9'
 default['osl-mysql']['backup_dir'] = '/data/backup'
 default['osl-mysql']['enable_percona_client'] = false
+default['osl-mysql']['test_mariadb_repo'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,4 +5,4 @@ default['osl-mysql']['monitor_user'] = 'monitor'
 default['osl-mysql']['xtrabackuprb']['version'] = '0.0.9'
 default['osl-mysql']['backup_dir'] = '/data/backup'
 default['osl-mysql']['enable_percona_client'] = false
-default['osl-mysql']['test_mariadb_repo'] = false
+default['osl-mysql']['test_mariadb_setup'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,4 +5,3 @@ default['osl-mysql']['monitor_user'] = 'monitor'
 default['osl-mysql']['xtrabackuprb']['version'] = '0.0.9'
 default['osl-mysql']['backup_dir'] = '/data/backup'
 default['osl-mysql']['enable_percona_client'] = false
-default['osl-mysql']['test_mariadb_setup'] = false

--- a/documentation/resource_osl_mysql_test.md
+++ b/documentation/resource_osl_mysql_test.md
@@ -6,7 +6,7 @@ All databases created are encoded as `utf8mb4_unicode_ci` by default.
 
 ### CentOS 7 Warning
 
-Due to the age of the version of MariaDB provided in the stock CentOS 7 repo, it is advised to use the `version` property to choose a newer release. By default, this resource will install version `10.11` if its on a CentOS 7 system.
+Due to the age of the version of MariaDB provided in the CentOS 7 distro repo, it is advised to use the `version` property to choose a newer release. We recommend to install version `10.11` if it's on a CentOS 7 system.
 
 ## Actions
 

--- a/documentation/resource_osl_mysql_test.md
+++ b/documentation/resource_osl_mysql_test.md
@@ -4,9 +4,9 @@ Installs and initializes a MariaDB service, alongside setting up a user and data
 
 All databases created are encoded as `utf8mb4_unicode_ci` by default.
 
-### CentOS 7 Warning
+### Fix for SQL-related converge errors
 
-Due to the age of the version of MariaDB provided in the CentOS 7 distro repo, it is advised to use the `version` property to choose a newer release. We recommend to install version `10.11` if it's on a CentOS 7 system.
+Due to the age of the version of MariaDB provided by some distro repositories, you may come across an issue like: **Specified key was too long; max key length is ... bytes** while converging. To fix issues like this, add in the `version` property to the resource to install a newer version of MariaDB. It is recommended to install version `10.11`. To look at other versions that are available, check out [MariaDB's mirror website](http://mirror.mariadb.org/yum/)
 
 ## Actions
 

--- a/documentation/resource_osl_mysql_test.md
+++ b/documentation/resource_osl_mysql_test.md
@@ -4,6 +4,10 @@ Installs and initializes a MariaDB service, alongside setting up a user and data
 
 All databases created are encoded as `utf8mb4_unicode_ci` by default.
 
+### CentOS 7 Warning
+
+Due to the age of the version of MariaDB provided in the stock CentOS 7 repo, it is advised to use the `version` property to choose a newer release. By default, this resource will install version `10.11` if its on a CentOS 7 system.
+
 ## Actions
 
 - create - (default) to install MariaDB, create a user, and create a database
@@ -12,12 +16,13 @@ All databases created are encoded as `utf8mb4_unicode_ci` by default.
 
 Name                 | Types    | Description                          | Default              | Required?
 ---------            | -------- | ----------------------------------   | ------------         | ---------
-`Database`           | String   | The name of the database to create   |                      | yes
-`Username`           | String   | The owner of the database created    |                      | yes
-`Password`           | String   | The password to give the user        |                      | yes
+`database`           | String   | The name of the database to create   |                      | yes
+`username`           | String   | The owner of the database created    |                      | yes
+`password`           | String   | The password to give the user        |                      | yes
 `server_password`    | String   | The root password                    | osl\_mysql\_test     | no
 `encoding`           | String   | The string encoding for the database | utf8mb4              | no
 `collation`          | String   | The collation for the database       | utf8mb4\_unicode\_ci | no
+`version`            | String   | Enables the MariaDB repo and installs the requested version of the database | null | no
 `database_parameters`| Hash     | Extra database arguments to pass through, see [mariadb\_database](https://github.com/sous-chefs/mariadb/blob/main/documentation/resource_mariadb_database.md) |  | no
 
 ### Examples
@@ -43,5 +48,13 @@ osl_mysql_test 'db_three' do
   password 'db_password'
   encoding 'latin1'
   collation 'latin1_swedish_ci'
+end
+
+# Use a newer version of MariaDB, and change the root password
+osl_mysql_test 'db_four' do
+  username 'db_owner'
+  password 'db_password'
+  server_password 'foo on the bar with baz'
+  version '10.11'
 end
 ```

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -38,7 +38,9 @@ action :create do
   end
   # Ensure that large prefix size is enabled on centos 7
   mariadb_database 'Increase prefix size' do
-    query 'SET GLOBAL innodb_large_prefix = 1;'
+    sql 'SET GLOBAL innodb_large_prefix = 1;'
+    password new_resource.server_password
+    action [:query]
     only_if { platform?('centos') && node['platform_version'] == "7.9.2009" }
   end
 end

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -36,4 +36,9 @@ action :create do
     database_name new_resource.database
     action [:create, :grant]
   end
+  # Ensure that large prefix size is enabled on centos 7
+  mariadb_database 'Increase prefix size' do
+    query 'SET GLOBAL innodb_large_prefix = 1;'
+    only_if { platform?('centos') && node['platform_version'] == "7.9.2009" }
+  end
 end

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -10,12 +10,12 @@ property :password, String, required: true
 property :server_password, String, default: 'osl_mysql_test'
 property :encoding, String, default: 'utf8mb4'
 property :collation, String, default: 'utf8mb4_unicode_ci'
-property :version, [String, nil]
+property :version, String
 property :database_parameters, Hash, default: {}
 
 # Install the mariadb package, set up the service, set up the user, then set up the given database
 action :create do
-  # Setup the epel repo if we are installing from MariaDB
+  # Setup the epel repo if we are installing from MariaDB as the MariaDB version depends on a package found in epel.
   include_recipe 'osl-repos::epel' if new_resource.version
 
   # Install the database packages, dependent on if the version property is set

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -38,7 +38,7 @@ action :create do
   end
   # Ensure that large prefix size is enabled on centos 7
   mariadb_database 'Increase prefix size' do
-    sql 'SET GLOBAL innodb_large_prefix = 1;'
+    sql 'SET GLOBAL innodb_large_prefix = 1; SET GLOBAL innodb_default_for_format = dynamic;'
     password new_resource.server_password
     action [:query]
     only_if { platform?('centos') && node['platform_version'] == "7.9.2009" }

--- a/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
+++ b/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
@@ -38,4 +38,3 @@ begin
 rescue
   # Nothing
 end
-

--- a/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
+++ b/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
@@ -1,16 +1,8 @@
-if platform?('centos') && Gem::Version.create(node['platform_version']) < Gem::Version.create(8)
-  # Initialize the database service, and create a database
-  osl_mysql_test 'foobar' do
-    version '10.11'
-    username 'foo'
-    password 'foofoo'
-  end
-else
-  # Initialize the database service, and create a database
-  osl_mysql_test 'foobar' do
-    username 'foo'
-    password 'foofoo'
-  end
+# Initialize the database service, and create a database
+osl_mysql_test 'foobar' do
+  version '10.11' if node['platform_version'].to_i < 8
+  username 'foo'
+  password 'foofoo'
 end
 
 # Add in an extra database to the same user

--- a/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
+++ b/test/cookbooks/resources_test/recipes/osl_mysql_test.rb
@@ -1,7 +1,16 @@
-# Initialize the database service, and create a database
-osl_mysql_test 'foobar' do
-  username 'foo'
-  password 'foofoo'
+if platform?('centos') && Gem::Version.create(node['platform_version']) < Gem::Version.create(8)
+  # Initialize the database service, and create a database
+  osl_mysql_test 'foobar' do
+    version '10.11'
+    username 'foo'
+    password 'foofoo'
+  end
+else
+  # Initialize the database service, and create a database
+  osl_mysql_test 'foobar' do
+    username 'foo'
+    password 'foofoo'
+  end
 end
 
 # Add in an extra database to the same user
@@ -29,3 +38,4 @@ begin
 rescue
   # Nothing
 end
+

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -32,8 +32,4 @@ if os.release == '7.9.2009'
   describe mysql_session('root', 'osl_mysql_test').query('SHOW VARIABLES LIKE \'innodb_large_prefix\'') do
     its('output') { should match /ON/ }
   end
-else
-  describe mysql_session('root', 'osl_mysql_test').query('SHOW VARIABLES LIKE \'innodb_large_prefix\'') do
-    its('output') { should match /OFF/ }
-  end
 end

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -7,7 +7,7 @@ end
 
 describe port(3306) do
   it { should be_listening }
-  its('processes') { should cmp 'mysqld' }
+  its('processes') { should be_in %w(mysqld mariadbd) }
 end
 
 # Check to see if the datbases foobar and barfoo exist.

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -26,3 +26,14 @@ end
 describe mysql_session('root', 'osl_mysql_test').query('SHOW DATABASES LIKE \'failing_db\'') do
   its('output') { should eq '' }
 end
+
+# Check to see if in the event we are using CentOS, that innodb_large_prefix is enabled.
+if os.release == '7.9.2009'
+  describe mysql_session('root', 'osl_mysql_test').query('SHOW VARIABLES LIKE \'innodb_large_prefix\'') do
+    its('output') { should match /ON/ }
+  end
+else
+  describe mysql_session('root', 'osl_mysql_test').query('SHOW VARIABLES LIKE \'innodb_large_prefix\'') do
+    its('output') { should match /OFF/ }
+  end
+end

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -26,10 +26,3 @@ end
 describe mysql_session('root', 'osl_mysql_test').query('SHOW DATABASES LIKE \'failing_db\'') do
   its('output') { should eq '' }
 end
-
-# Check to see if in the event we are using CentOS, that innodb_large_prefix is enabled.
-if os.release == '7.9.2009'
-  describe mysql_session('root', 'osl_mysql_test').query('SHOW VARIABLES LIKE \'innodb_large_prefix\'') do
-    its('output') { should match /ON/ }
-  end
-end

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -10,6 +10,14 @@ describe port(3306) do
   its('processes') { should be_in %w(mysqld mariadbd) }
 end
 
+if os.release.to_i < 8
+  # Check to make sure that CentOS 7's version is exactly 10.11
+  describe bash('mysql --version') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match '10.11.3' }
+  end
+end
+
 # Check to see if the datbases foobar and barfoo exist.
 # Using the user foo, to also verify that user exists.
 describe mysql_session('foo', 'foofoo').query('USE foobar; USE barfoo') do


### PR DESCRIPTION
There were issues of CentOS 7 nodes failing to converge due to the version of MariaDB that is available by default was extremely outdated and underspec'd for what the test DBs required.

The new `version` attribute will bring in MariaDB's own repository and install the specified version from there.

Along with this, to make writing tests in other cookbooks easier, the resource will now automatically patch in the `10.11` version of MariaDB if it's being utilized on CentOS 7, and a version is not specified.