### PR TITLE
Add firewall port rules for mysql in osl_mysql_test

### DIFF
--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -16,7 +16,9 @@ property :database_parameters, Hash, default: {}
 # Install the mariadb package, set up the service, set up the user, then set up the given database
 action :create do
   # Setup the port for mysql
-  osl_firewall_port 'mysql'
+  osl_firewall_port 'mysql' do
+    osl_only false
+  end
   # Setup the epel repo if we are installing from MariaDB as the MariaDB version depends on a package found in epel.
   include_recipe 'osl-repos::epel' if new_resource.version
 

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -15,6 +15,8 @@ property :database_parameters, Hash, default: {}
 
 # Install the mariadb package, set up the service, set up the user, then set up the given database
 action :create do
+  # Setup the port for mysql
+  osl_firewall_port 'mysql'
   # Setup the epel repo if we are installing from MariaDB as the MariaDB version depends on a package found in epel.
   include_recipe 'osl-repos::epel' if new_resource.version
 

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -10,6 +10,12 @@ describe port(3306) do
   its('processes') { should be_in %w(mysqld mariadbd) }
 end
 
+# Firewall rules should allow mysql
+describe iptables do
+  it { should have_rule('-A INPUT -j mysql') }
+  it { should have_rule('-A mysql -p tcp -m tcp --dport 3306 -j osl_only') }
+end
+
 if os.release.to_i < 8
   # Check to make sure that CentOS 7's version is exactly 10.11
   describe bash('mysql --version') do

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -20,7 +20,7 @@ if os.release.to_i < 8
   # Check to make sure that CentOS 7's version is exactly 10.11
   describe bash('mysql --version') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match '10.11.3' }
+    its('stdout') { should match 'Distrib 10.11' }
   end
 end
 

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -13,7 +13,7 @@ end
 # Firewall rules should allow mysql
 describe iptables do
   it { should have_rule('-A INPUT -j mysql') }
-  it { should have_rule('-A mysql -p tcp -m tcp --dport 3306') }
+  it { should have_rule('-A mysql -p tcp -m tcp --dport 3306 -j ACCEPT') }
 end
 
 if os.release.to_i < 8

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -13,7 +13,7 @@ end
 # Firewall rules should allow mysql
 describe iptables do
   it { should have_rule('-A INPUT -j mysql') }
-  it { should have_rule('-A mysql -p tcp -m tcp --dport 3306 -j osl_only') }
+  it { should have_rule('-A mysql -p tcp -m tcp --dport 3306') }
 end
 
 if os.release.to_i < 8


### PR DESCRIPTION
This should allow for outbound/inbound traffic of MySQL for test databases.