### PR TITLE
Add localhost grant to osl_mysql_test to fix auth failure

### DIFF
--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -25,3 +25,9 @@ platforms:
       image_ref: "AlmaLinux 8"
     transport:
       username: almalinux
+  - name: almalinux-9
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 9"
+    transport:
+      username: almalinux

--- a/resources/osl_mysql_test.rb
+++ b/resources/osl_mysql_test.rb
@@ -40,11 +40,20 @@ action :create do
     end
   end
   # Grant privilages
-  mariadb_user new_resource.username do
+  mariadb_user "#{new_resource.username}-remote" do
+    username new_resource.username
     ctrl_password new_resource.server_password
     password new_resource.password
     database_name new_resource.database
     host '%'
+    action [:create, :grant]
+  end
+
+  mariadb_user new_resource.username do
+    ctrl_password new_resource.server_password
+    password new_resource.password
+    database_name new_resource.database
+    host 'localhost'
     action [:create, :grant]
   end
 

--- a/spec/osl_mysql_test_spec.rb
+++ b/spec/osl_mysql_test_spec.rb
@@ -36,10 +36,31 @@ describe 'osl_mysql_test' do
     end
 
     it do
+      is_expected.to create_mariadb_user('foo-remote').with(
+        username: 'foo',
+        ctrl_password: 'osl_mysql_test',
+        password: 'bar',
+        database_name: 'db-one',
+        host: '%'
+      )
+    end
+
+    it do
+      is_expected.to grant_mariadb_user('foo-remote').with(
+        username: 'foo',
+        ctrl_password: 'osl_mysql_test',
+        password: 'bar',
+        database_name: 'db-one',
+        host: '%'
+      )
+    end
+
+    it do
       is_expected.to create_mariadb_user('foo').with(
         ctrl_password: 'osl_mysql_test',
         password: 'bar',
-        database_name: 'db-one'
+        database_name: 'db-one',
+        host: 'localhost'
       )
     end
 
@@ -47,7 +68,8 @@ describe 'osl_mysql_test' do
       is_expected.to grant_mariadb_user('foo').with(
         ctrl_password: 'osl_mysql_test',
         password: 'bar',
-        database_name: 'db-one'
+        database_name: 'db-one',
+        host: 'localhost'
       )
     end
 

--- a/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
+++ b/test/integration/osl_mysql_test/controls/osl_mysql_test.rb
@@ -37,6 +37,13 @@ describe mysql_session('bar', 'barbar').query('USE newuser_db; SELECT @@collatio
   its('output') { should match /latin1_swedish_ci/ }
 end
 
+# Verify that both localhost and % host grants exist for user foo
+describe mysql_session('root', 'osl_mysql_test').query("SELECT host FROM mysql.user WHERE user = 'foo' ORDER BY host") do
+  its('exit_status') { should eq 0 }
+  its('output') { should match /%/ }
+  its('output') { should match /localhost/ }
+end
+
 # Check to ensure that the failed resource did not go through
 describe mysql_session('root', 'osl_mysql_test').query('SHOW DATABASES LIKE \'failing_db\'') do
   its('output') { should eq '' }


### PR DESCRIPTION
MariaDB's anonymous user ''@'localhost' has higher host specificity than
'user'@'%', causing login failures when connecting locally. The anonymous
user is matched first, and authentication fails due to a password mismatch.

Add a separate localhost grant in addition to the wildcard (%) grant so
that 'user'@'localhost' takes priority over the anonymous user. The remote
grant is preserved for Docker container and other non-local connections.

Update unit and integration tests to cover both grant types.

Also add AlmaLinux 9 platform to kitchen.openstack.yml.

Signed-off-by: Lance Albertson <lance@osuosl.org>
